### PR TITLE
Update formulae with log paths

### DIFF
--- a/sketchybar.rb
+++ b/sketchybar.rb
@@ -49,6 +49,8 @@ class Sketchybar < Formula
     environment_variables PATH: std_service_path_env, LANG: "en_US.UTF-8"
     keep_alive true
     process_type :interactive
+    log_path "#{var}/log/sketchybar/sketchybar.out.log"
+    error_log_path "#{var}/log/sketchybar/sketchybar.err.log"
   end
 
   test do


### PR DESCRIPTION
For some time my sketchybar logs were not showing, thought the issue was on my side thinking otherwise it would've popped up on issues already. 
After fiddling with it for some time on my local found out that log directories got lost with https://github.com/FelixKratz/homebrew-formulae/commit/292af120c0a3a8b8f21a5c330030d0321eef6a84, since `log_path` and `error_log_path` does not have default values (https://docs.brew.sh/Formula-Cookbook#service-block-methods)